### PR TITLE
Redirect to success login redirect when already logged in

### DIFF
--- a/Controller/LoginController.php
+++ b/Controller/LoginController.php
@@ -2,6 +2,8 @@
 
 namespace SumoCoders\FrameworkMultiUserBundle\Controller;
 
+use SumoCoders\FrameworkMultiUserBundle\Security\FormAuthenticator;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
@@ -17,15 +19,31 @@ final class LoginController
     private $authenticationUtils;
 
     /**
+     * @var FormAuthenticator
+     */
+    private $formAuthenticator;
+
+    /**
+     * @var TokenStorage
+     */
+    private $tokenStorage;
+
+    /**
      * @param EngineInterface $templating
      * @param AuthenticationUtils $authenticationUtils
+     * @param FormAuthenticator $formAuthenticator
+     * @param TokenStorage $tokenStorage
      */
     public function __construct(
         EngineInterface $templating,
-        AuthenticationUtils $authenticationUtils
+        AuthenticationUtils $authenticationUtils,
+        FormAuthenticator $formAuthenticator,
+        TokenStorage $tokenStorage
     ) {
         $this->templating = $templating;
         $this->authenticationUtils = $authenticationUtils;
+        $this->formAuthenticator = $formAuthenticator;
+        $this->tokenStorage = $tokenStorage;
     }
 
     /**
@@ -33,6 +51,12 @@ final class LoginController
      */
     public function loginAction(Request $request)
     {
+        if ($this->tokenStorage->getToken()->getUser() instanceof User) {
+            return new RedirectResponse(
+                $this->formAuthenticator->getSuccessRedirectUrl($this->tokenStorage->getToken())
+            );
+        }
+
         $exception = $this->authenticationUtils->getLastAuthenticationError();
 
         return $this->templating->renderResponse(

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,6 +11,8 @@ services:
     arguments:
       - "@templating"
       - "@security.authentication_utils"
+      - "@sumocoders.form_authenticator"
+      - "@security.token_storage"
 
   multi_user.handler.request_password:
       class: SumoCoders\FrameworkMultiUserBundle\Command\RequestPasswordResetHandler

--- a/Security/FormAuthenticator.php
+++ b/Security/FormAuthenticator.php
@@ -103,7 +103,7 @@ class FormAuthenticator extends AbstractFormLoginAuthenticator
         return new RedirectResponse($targetPath);
     }
 
-    protected function getSuccessRedirectUrl(TokenInterface $token)
+    public function getSuccessRedirectUrl(TokenInterface $token)
     {
         foreach ($this->redirectRoutes as $class => $route) {
             if (get_class($token->getUser()) === $class) {


### PR DESCRIPTION
When you try to go to the login page, you shouldn't see the login form again, you should be redirect to the success login redirect.