### PR TITLE
Update routing.md

### DIFF
--- a/Resources/doc/routing.md
+++ b/Resources/doc/routing.md
@@ -29,7 +29,7 @@ security:
   firewalls:
     my_firewall:
       logout:
-        path:   /%locale%/logout
+        path: multi_user_logout
         target: /
 ```
 


### PR DESCRIPTION
You have to use the route name in the security.yml file for the logout path and not `/%locale%/logout`.
This only worked for 1 languages. 
When logging out in a second language you get the error `controller not found for path ....`