### PR TITLE
Fix FormAuthenticator URL matching

### DIFF
--- a/Security/FormAuthenticator.php
+++ b/Security/FormAuthenticator.php
@@ -86,7 +86,7 @@ class FormAuthenticator extends AbstractFormLoginAuthenticator
 
     public function supports(Request $request)
     {
-        return $request->getBasePath() === '/login' && $request->isMethod('POST');
+        return preg_match('/\/\w{2}\/login/', $request->getRequestUri()) !== false  && $request->isMethod('POST');
     }
 
     protected function getLoginUrl(): string


### PR DESCRIPTION
We were using the BasePath to match the URI the FormAuthenticator supports. In Symfony 3.4 this doesn't seem to work.
In this PR I changed it to use the request URI from the request and use a regex to do the matching.