### PR TITLE
Fix user serialization

### DIFF
--- a/Entity/BaseUser.php
+++ b/Entity/BaseUser.php
@@ -9,13 +9,15 @@ use SumoCoders\FrameworkMultiUserBundle\Security\PasswordResetToken;
 use SumoCoders\FrameworkMultiUserBundle\User\Interfaces\User;
 use SumoCoders\FrameworkMultiUserBundle\ValueObject\Status;
 use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
+use Symfony\Component\Security\Core\User\EquatableInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * @ORM\Entity(repositoryClass="SumoCoders\FrameworkMultiUserBundle\User\DoctrineBaseUserRepository")
  * @ORM\InheritanceType("JOINED")
  * @ORM\DiscriminatorColumn(name="discr", type="string")
  */
-class BaseUser implements User, Serializable
+class BaseUser implements User, Serializable, EquatableInterface
 {
     /**
      * @var int
@@ -249,5 +251,10 @@ class BaseUser implements User, Serializable
     public function unserialize($serialized): void
     {
         [$this->id, $this->username, $this->password, $this->salt] = unserialize($serialized);
+    }
+
+    public function isEqualTo(UserInterface $user): bool
+    {
+        return $user->getUsername() === $this->getUsername();
     }
 }

--- a/Entity/BaseUser.php
+++ b/Entity/BaseUser.php
@@ -253,6 +253,10 @@ class BaseUser implements User, Serializable, EquatableInterface
 
     public function isEqualTo(UserInterface $user): bool
     {
-        return $user->getUsername() === $this->getUsername();
+        if ($user instanceof self) {
+            return $user->getId() === $this->getId();
+        }
+
+        return false;
     }
 }

--- a/Entity/BaseUser.php
+++ b/Entity/BaseUser.php
@@ -3,6 +3,7 @@
 namespace SumoCoders\FrameworkMultiUserBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Serializable;
 use SumoCoders\FrameworkMultiUserBundle\DataTransferObject\Interfaces\UserDataTransferObject;
 use SumoCoders\FrameworkMultiUserBundle\Security\PasswordResetToken;
 use SumoCoders\FrameworkMultiUserBundle\User\Interfaces\User;
@@ -14,7 +15,7 @@ use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
  * @ORM\InheritanceType("JOINED")
  * @ORM\DiscriminatorColumn(name="discr", type="string")
  */
-class BaseUser implements User
+class BaseUser implements User, Serializable
 {
     /**
      * @var int
@@ -231,5 +232,22 @@ class BaseUser implements User
     public function canSwitchTo(BaseUser $user): bool
     {
         return false;
+    }
+
+    public function serialize(): string
+    {
+        return serialize(
+            [
+                $this->id,
+                $this->username,
+                $this->password,
+                $this->salt,
+            ]
+        );
+    }
+
+    public function unserialize($serialized): void
+    {
+        [$this->id, $this->username, $this->password, $this->salt] = unserialize($serialized);
     }
 }

--- a/Entity/BaseUser.php
+++ b/Entity/BaseUser.php
@@ -242,15 +242,13 @@ class BaseUser implements User, Serializable, EquatableInterface
             [
                 $this->id,
                 $this->username,
-                $this->password,
-                $this->salt,
             ]
         );
     }
 
     public function unserialize($serialized): void
     {
-        [$this->id, $this->username, $this->password, $this->salt] = unserialize($serialized);
+        [$this->id, $this->username] = unserialize($serialized);
     }
 
     public function isEqualTo(UserInterface $user): bool


### PR DESCRIPTION
The User entity gets serialized and stored in session during the request lifetime. Many times it happens that the user entity has relations with other entities, which means Symfony will serialize the User object and its relations and store it in the session. This could lead to out-of-memory situations where user simply gets logged out without any warning.
This PR fixes this use case by only storing fundamental information in the session.